### PR TITLE
changelog: clean squash-commit-message to not break markdown table

### DIFF
--- a/utils/git/changelog.go
+++ b/utils/git/changelog.go
@@ -2,15 +2,17 @@ package git
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	goUtils "github.com/analogj/go-util/utils"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/storer"
-	"strings"
 )
 
-//https://github.com/go-git/go-git/issues/36
+// https://github.com/go-git/go-git/issues/36
 func GitGenerateChangelog(repoPath string, baseSha string, headSha string) (string, error) {
 	repo, oerr := git.PlainOpen(repoPath)
 	if oerr != nil {
@@ -64,7 +66,17 @@ func cleanCommitMessage(commitMessage string) string {
 		return "--"
 	}
 
+	// replace pipe characters as they delimit table colums in markdown
 	commitMessage = strings.Replace(commitMessage, "|", "/", -1)
+
+	// normalize and squash consecutive newlines to single linefeed character
+	re := regexp.MustCompile(`(\r?\n)+`)
+	commitMessage = re.ReplaceAllString(commitMessage, "\n")
+
+	// assume lines starting with '* ' are bullet lists resulting from squashed commits
+	commitMessage = strings.Replace(commitMessage, "\n* ", "<li>", -1)
+
+	// clean up remaining newline characters
 	commitMessage = strings.Replace(commitMessage, "\n", " ", -1)
 
 	return commitMessage

--- a/utils/git/changelog_test.go
+++ b/utils/git/changelog_test.go
@@ -35,3 +35,17 @@ func TestGitGenerateChangelog(t *testing.T) {
 2019-10-03T15:35Z | f6f820c1 | Update README.md | Jason Kulatunga
 `, changelog)
 }
+
+// Validate handling of commit messages from PR squash merges.
+// Github creates squash commits with cr/lf line endings and creates a list of all squashed commit messages using asterisk list headers.
+func TestCleanCommitMessageFromSquash(t *testing.T) {
+
+	//setup
+	squashCommit := "Commit a (#13)\n\n* Commit a\r\n\r\n* commit b\r\n\r\n* another commit"
+
+	//test
+	cleanedMsg := cleanCommitMessage(squashCommit)
+
+	//assert
+	require.Equal(t, "Commit a (#13)<li>Commit a<li>commit b<li>another commit", cleanedMsg)
+}


### PR DESCRIPTION
Fixes https://github.com/PackagrIO/publishr/issues/9

Additional logic in cleanCommitMessage() to handle:
- CR/LF linefeeds
- fold consecutive linefeeds into single newline
- reformat squash commit messages using `<li>` elements to preserve the list of squashed commits